### PR TITLE
Modeling diamagnetic bubble transition layer, update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin-int/
 log/
 results/
 *.bin
+*.npy

--- a/simulation.mk
+++ b/simulation.mk
@@ -23,8 +23,9 @@ SRCS +=                                       \
   src/diagnostics/whole_field.cpp             \
   src/diagnostics/field_on_segment.cpp        \
   src/diagnostics/field_at_point.cpp          \
-  src/diagnostics/distribution_moment.cpp     \
   src/diagnostics/chosen_particles.cpp        \
+  src/diagnostics/distribution_moment.cpp     \
+  src/diagnostics/x0_distribution_function.cpp\
   src/diagnostics/diagnostics_builder.cpp     \
 
 # fields

--- a/src/command/clone_layer_particles.cpp
+++ b/src/command/clone_layer_particles.cpp
@@ -1,9 +1,18 @@
 #include "clone_layer_particles.hpp"
 
 Clone_layer_particles::Clone_layer_particles(
-  Particles* const particles_inout, Domain_geometry geom)
+  Particles* const particles_inout,
+  Domain_geometry geom)
   :	particles_in_(particles_inout),
     particles_out_(particles_inout),
+    geom_(geom) {}
+
+Clone_layer_particles::Clone_layer_particles(
+  Particles* const particles_in,
+  Particles* const particles_out,
+  Domain_geometry geom)
+  :	particles_in_(particles_in),
+    particles_out_(particles_out),
     geom_(geom) {}
 
 void Clone_layer_particles::execute(int /* timestep */) const {

--- a/src/command/clone_layer_particles.cpp
+++ b/src/command/clone_layer_particles.cpp
@@ -3,7 +3,7 @@
 Clone_layer_particles::Clone_layer_particles(
   Particles* const particles_inout,
   Domain_geometry geom)
-  :	particles_in_(particles_inout),
+  : particles_in_(particles_inout),
     particles_out_(particles_inout),
     geom_(geom) {}
 
@@ -11,7 +11,7 @@ Clone_layer_particles::Clone_layer_particles(
   Particles* const particles_in,
   Particles* const particles_out,
   Domain_geometry geom)
-  :	particles_in_(particles_in),
+  : particles_in_(particles_in),
     particles_out_(particles_out),
     geom_(geom) {}
 
@@ -22,15 +22,15 @@ void Clone_layer_particles::execute(int /* timestep */) const {
 
   #pragma omp parallel for num_threads(NUM_THREADS)
   for (auto it = particles_in_->particles_.begin(); it != particles_fixed_end; ++it) {
-    if (particle_should_cloned(it->point)) {
+    if (particle_be_should_cloned(it->point)) {
       particles_out_->add_particle(configure_point(it->point));
     }
   }
 }
 
 inline bool
-Clone_layer_particles::particle_should_cloned(const Point& point) const {
-  double width = particles_in_->get_parameters().charge_cloud() * dx;
+Clone_layer_particles::particle_be_should_cloned(const Point& point) const {
+  double width = particles_in_->get_parameters().charge_cloud() * config::COPY_LAYER_MULT * dx;
 
   return particle_on_the_left(point.x(), width) ||
     particle_on_the_right(point.x(), width);
@@ -48,7 +48,7 @@ Clone_layer_particles::particle_on_the_right(double x, double width) const {
 
 inline Point
 Clone_layer_particles::configure_point(const Point& point) const {
-  double width = particles_in_->get_parameters().charge_cloud() * dx;
+  double width = particles_in_->get_parameters().charge_cloud() * config::COPY_LAYER_MULT * dx;
 
   double new_x = particle_on_the_left(point.x(), width)?
     2 * geom_.left - point.x():

--- a/src/command/clone_layer_particles.hpp
+++ b/src/command/clone_layer_particles.hpp
@@ -26,7 +26,7 @@ class Clone_layer_particles : public Command {
 
   Domain_geometry geom_;
 
-  inline bool particle_should_cloned(const Point&) const;
+  inline bool particle_be_should_cloned(const Point&) const;
   inline bool particle_on_the_left(double x, double width) const;
   inline bool particle_on_the_right(double x, double width) const;
 

--- a/src/command/clone_layer_particles.hpp
+++ b/src/command/clone_layer_particles.hpp
@@ -9,7 +9,14 @@
 
 class Clone_layer_particles : public Command {
  public:
-  Clone_layer_particles(Particles* const particles_inout, Domain_geometry geom);
+  Clone_layer_particles(
+    Particles* const particles_inout,
+    Domain_geometry geom);
+  
+  Clone_layer_particles(
+    Particles* const particles_in,
+    Particles* const particles_out,
+    Domain_geometry geom);
 
   void execute(int /* timestep */) const override;
 

--- a/src/command/copy_coordinates.hpp
+++ b/src/command/copy_coordinates.hpp
@@ -1,55 +1,42 @@
 #ifndef COMMAND_COPY_COORDINATES_HPP
 #define COMMAND_COPY_COORDINATES_HPP
 
-//#######################################################################################
-
 #include "command.hpp"
 
 #include "src/pch.h"
-#include "../particles/particles.hpp"
+#include "src/particles/particles.hpp"
+#include "src/particles/particles_load.hpp"
 
 /**
  * @brief Command to copy coordinates from another particles.
  */
 class Copy_coordinates : public Command {
-public:
-	
-    /**
-     * @brief Constructor of the command.
-     * 
-     * @param particles_that_copies Pointer on particles that will copy coordinates. 
-     * @param particles_to_copy Pointer on particles which will share coordinates.
-     * @param load_impulse Impulse distribution function.
-     */
-	Copy_coordinates(
-		Particles* const particles_that_copies,
-        const Particles* const particles_to_copy,
-        std::function<void(double x, double y,
-		  double mass, double Tx, double Ty, double Tz,
-		  double p0, double* px, double* py, double* pz)> load_impulse)
-		  : particles_that_copies(particles_that_copies),
-            particles_to_copy(particles_to_copy),
-            load_impulse(load_impulse) {};
+ public:
 
-    /**
-     * @brief Passes through every particle of particles_to_copy vector,
-     *      copies coordinates from it to particles_that_copies and 
-     *      gives to this points another impulse.
-     * 
-     * @param _ Placeholder for the time, pass 0.
-     */
-	void execute(int _) const override;
+  /**
+   * @brief Constructor of the command.
+   *
+   * @param particles_copy_to Pointer on particles that will copy coordinates.
+   * @param particles_copy_from Pointer on particles which will share coordinates.
+   * @param load_impulse Impulse distribution function.
+   */
+  Copy_coordinates(
+    Particles* const particles_copy_to,
+    const Particles* const particles_copy_from,
+    const impulse_loader& load_impulse);
 
-private:
-	Particles* const particles_that_copies;
+  /**
+   * @brief Passes through every particle of particles_copy_from vector,
+   *  copies coordinates from it to particles_copy_to and
+   *  gives to this points another impulse.
+   */
+  void execute(int /* timestep */) const override;
 
-    const Particles* const particles_to_copy;
-    
-    std::function<void(double x, double y,
-	    double mass, double Tx, double Ty, double Tz,
-	    double p0, double* px, double* py, double* pz)> load_impulse;    
+ private:
+  Particles* const particles_copy_to_;
+  const Particles* const particles_copy_from_;
+
+  impulse_loader load_impulse_;
 };
-
-//#######################################################################################
 
 #endif // COMMAND_COPY_COORDINATES_HPP

--- a/src/command/magnetic_field_half_step.cpp
+++ b/src/command/magnetic_field_half_step.cpp
@@ -1,36 +1,37 @@
 #include "magnetic_field_half_step.hpp"
 #include <omp.h>
 
-void Magnetic_field_half_step::execute(int _) const
+void Magnetic_field_half_step::execute(int /* timestep */) const
 {
-	vector3_field& E = fields_->E();
-	vector3_field& B = fields_->B();
-	
-		#pragma omp parallel shared(E, B), num_threads(NUM_THREADS)
-	{
-		// Bx(y, x+1/2) at t+1/2 ----------------------------------------------------
-		#pragma omp for 
-		for (int ny = B.iy_first(X); ny < B.iy_last(X); ++ny) {
-			for (int nx = B.ix_first(X); nx < B.ix_last(X); ++nx) {
-				B.x(ny,nx) -= 0.5*(E.z(ny,nx) - E.z(ny-1,nx))*dt/dy;			
-			}
-		}	
+  vector3_field& E = fields_->E();
+  vector3_field& B = fields_->B();
+  
+#pragma omp parallel shared(E, B), num_threads(NUM_THREADS)
+{
+  // Bx(y, x+1/2) at t+1/2
+  #pragma omp for 
+  for (int ny = B.iy_first(X); ny < B.iy_last(X); ++ny) {
+    for (int nx = B.ix_first(X); nx < B.ix_last(X); ++nx) {
+      B.x(ny, nx) -= 0.5 * (E.z(ny, nx) - E.z(ny-1, nx)) * dt / dy;			
+    }
+  }	
 
-		// By(y+1/2, x) at t+1/2 ----------------------------------------------------
-		#pragma omp for
-		for (int ny = B.iy_first(Y); ny < B.iy_last(Y); ++ny) {
-			for (int nx = B.ix_first(Y); nx < B.ix_last(Y); ++nx) {
-				B.y(ny,nx) += 0.5*(E.z(ny,nx) - E.z(ny,nx-1))*dt/dx;
-			}
-		}
-	
-		// Bz(y, x) at t+1/2 --------------------------------------------------------
-		#pragma omp for
-		for (int ny = B.iy_first(Z); ny < B.iy_last(Z); ++ny) {
-			for (int nx = B.ix_first(Z); nx < B.ix_last(Z); ++nx) {
-				B.z(ny,nx) -= 0.5*((E.y(ny,nx+1) - E.y(ny,nx))/dx 
-								 - (E.x(ny+1,nx) - E.x(ny,nx))/dy)*dt;
-			}
-		}
-	}
+  // By(y+1/2, x) at t+1/2
+  #pragma omp for
+  for (int ny = B.iy_first(Y); ny < B.iy_last(Y); ++ny) {
+    for (int nx = B.ix_first(Y); nx < B.ix_last(Y); ++nx) {
+      B.y(ny, nx) += 0.5 * (E.z(ny, nx) - E.z(ny, nx-1)) * dt / dx;
+    }
+  }
+  
+  // Bz(y, x) at t+1/2
+  #pragma omp for
+  for (int ny = B.iy_first(Z); ny < B.iy_last(Z); ++ny) {
+    for (int nx = B.ix_first(Z); nx < B.ix_last(Z); ++nx) {
+      B.z(ny, nx) -= 0.5 * (
+        (E.y(ny, nx+1) - E.y(ny, nx)) / dx -
+        (E.x(ny+1, nx) - E.x(ny, nx)) / dy) * dt;
+    } 
+  }
+}
 }

--- a/src/command/magnetic_field_half_step.hpp
+++ b/src/command/magnetic_field_half_step.hpp
@@ -1,25 +1,20 @@
 #ifndef MAGNETIC_FIELD_HALF_STEP
 #define MAGNETIC_FIELD_HALF_STEP
 
-//#######################################################################################
-
 #include "command.hpp"
 
-#include "../fields/fields.hpp"
-
+#include "src/fields/fields.hpp"
 
 class Magnetic_field_half_step : public Command {
 public:
-	Magnetic_field_half_step(Fields* fields)
-		: fields_(fields) {};
-		
-	void execute(int t) const override;
+  Magnetic_field_half_step(Fields* fields)
+    : fields_(fields) {};
+    
+  void execute(int /* timestep */) const override;
 
 private:
-	Fields* const fields_;	
-	double Bz0_;
+  Fields* const fields_;	
+  double Bz0_;
 };
-
-//#######################################################################################
 
 #endif // MAGNETIC_FIELD_HALF_STEPa

--- a/src/command/set_Bz_distribution.cpp
+++ b/src/command/set_Bz_distribution.cpp
@@ -14,7 +14,7 @@ void Set_Bz_distribution::execute(int /* timestep */) const {
     if (x * dx < __func.get_x0()) {
       continue;
     }
-    else if (x * dx < __func.get_xmax()) {
+    else if (x * dx <= __func.get_xmax()) {
       double fx = __func.get_value(x * dx);
       
       fields_->B().z(y, x) = config::Omega_max / M_SQRT_PI *

--- a/src/command/set_particles.cpp
+++ b/src/command/set_particles.cpp
@@ -24,7 +24,7 @@ void Set_particles::execute(int /* timestep */) const {
   const double p0   = particles_->get_parameters().p0();
 
   // чтобы не происходило ресайзов неожиданных
-  particles_->particles_.reserve(num_particles_to_load_ + 10'000);
+  particles_->particles_.reserve(num_particles_to_load_ + 100'000);
 
   for (std::size_t p_id = 0u; p_id < num_particles_to_load_; ++p_id) {
     double x, y;

--- a/src/command/set_particles.cpp
+++ b/src/command/set_particles.cpp
@@ -6,9 +6,7 @@ Set_particles::Set_particles(
   Particles* const particles,
   std::size_t num_particles_to_load,
   std::unique_ptr<Coordinate_generator> coordinate_generator,
-  std::function<void(double x, double y,
-    double mass, double Tx, double Ty, double Tz,
-    double p0, double* px, double* py, double* pz)> load_impulse)
+  const impulse_loader& load_impulse)
   : particles_(particles),
     num_particles_to_load_(num_particles_to_load),
     coordinate_generator_(std::move(coordinate_generator)),
@@ -16,6 +14,7 @@ Set_particles::Set_particles(
 
 void Set_particles::execute(int /* timestep */) const {
   PROFILE_FUNCTION();
+  LOG_TRACE("Setting {} distribution", particles_->get_name());
 
   const double mass = particles_->get_parameters().m();
   const double Tx   = particles_->get_parameters().Tx();

--- a/src/command/set_particles.cpp
+++ b/src/command/set_particles.cpp
@@ -26,6 +26,7 @@ void Set_particles::execute(int /* timestep */) const {
   // чтобы не происходило ресайзов неожиданных
   particles_->particles_.reserve(num_particles_to_load_ + 100'000);
 
+  #pragma omp parallel for num_threads(NUM_THREADS)
   for (std::size_t p_id = 0u; p_id < num_particles_to_load_; ++p_id) {
     double x, y;
     coordinate_generator_->load(&x, &y);

--- a/src/command/set_particles.hpp
+++ b/src/command/set_particles.hpp
@@ -5,6 +5,7 @@
 
 #include "src/pch.h"
 #include "src/particles/particles.hpp"
+#include "src/particles/particles_load.hpp"
 
 class Coordinate_generator {
  public:
@@ -22,9 +23,7 @@ class Set_particles : public Command {
     Particles* const particles,
     std::size_t num_particles_to_load,
     std::unique_ptr<Coordinate_generator> coordinate_generator,
-    std::function<void(double x, double y,
-      double mass, double Tx, double Ty, double Tz,
-      double p0, double* px, double* py, double* pz)> load_impulse);
+    const impulse_loader& load_impulse);
 
   void execute(int /* timestep */) const override;
 
@@ -35,9 +34,7 @@ class Set_particles : public Command {
 
   std::unique_ptr<Coordinate_generator> coordinate_generator_;
 
-  std::function<void(double x, double y,
-    double mass, double Tx, double Ty, double Tz,
-    double p0, double* px, double* py, double* pz)> load_impulse_;
+  impulse_loader load_impulse_;
 };
 
 #endif  // SRC_COMMAND_SET_PARTICLES_HPP

--- a/src/constants.h
+++ b/src/constants.h
@@ -39,6 +39,11 @@ inline const int diagnose_time_step = 1;
 
 namespace config {
 
+// This factor describes how many times the
+// width of the copy layer is greater than the
+// half-width of the one particle cloud
+inline const double COPY_LAYER_MULT = 1;
+
 inline const std::string boundaries = "cx_py";
 
 inline const double Omega_max = 0.5;

--- a/src/constants.h
+++ b/src/constants.h
@@ -43,16 +43,19 @@ inline const std::string boundaries = "cx_py";
 
 inline const double Omega_max = 0.5;
 
-inline const double n0 = 1.0;
-inline const int   Npe = 1;
-inline const double ni = 1.0;
-inline const int   Npi = 10;
-
-inline const double V_ions = 1.0 / 40.0;
 inline const double mi_me  = 16.0;
+
+// Ions velocity must satisfy the transverse
+// equilibrium condition: ½ mᵢn₀V² = Bᵥ²/8π
+inline const double V_ions = Omega_max / sqrt(mi_me);
 
 inline const char* path_to_parameter_function =
   "src/utils/transition_layer/evaluated_function_20.0X0_0.05DX_16.0mi_me.bin";
+
+inline const double n0 = 1.0;
+inline const int   Npe = 1;
+inline const double ni = 1.0;
+inline const int   Npi = 100;
 
 template<class K, class V>
 using umap = std::unordered_multimap<K, V>;
@@ -65,12 +68,13 @@ inline const umap<std::string,
 #if there_are_plasma_ions
   { "plasma_ions", {
     { "parameters", {
-        "global, " + to_string(n0),  // Particle density [in units of reference density]
-        "global, " + to_string(+e),  // Particle charge [in units of e]
-        to_string(mi_me),            // Particle mass [in units mₑ]
-        to_string(Npi),              // Number of particles representing the density n0
-        "0", "0", "0",               // Temperature in x, y and z direction [in KeV]
-        to_string(mi_me * V_ions)    // Absolute value of the initial impulse [in mₑc]
+        "global, " + to_string(n0),     // Particle density [in units of n₀]
+        "global, " + to_string(+e),     // Particle charge [in units of e]
+        to_string(mi_me),               // Particle mass [in units mₑ]
+        to_string(Npi),                 // Number of particles representing the density n₀
+        "0", "0", "0",                  // Temperature in x, y and z direction [in KeV]
+        to_string(mi_me * V_ions /      // Absolute value of the initial impulse [in mₑc]
+          sqrt(1.0 - V_ions * V_ions))
     }},
     { "integration_steps", {
         "Boris_pusher:+Push_particle",

--- a/src/constants.h
+++ b/src/constants.h
@@ -30,7 +30,7 @@ inline const double dx  = 0.05;
 inline const int SIZE_X = 1460;
 
 inline const double dy  = 0.05;
-inline const int SIZE_Y = 800;
+inline const int SIZE_Y = 400;
 
 inline const double dt = 0.5 * dx;
 inline const int TIME  = 1;
@@ -62,6 +62,17 @@ inline const int   Npe = 1;
 inline const double ni = 1.0;
 inline const int   Npi = 100;
 
+// Constants describing damping layer and calculation domain
+inline const int damping_layer_width = 30;
+inline const double damping_factor = 0.8;
+
+// Domain_geometry
+inline const double domain_left   = damping_layer_width * dx;
+inline const double domain_right  = (SIZE_X - damping_layer_width) * dx;
+inline const double domain_bottom = 0;
+inline const double domain_top    = SIZE_Y * dy;
+
+
 template<class K, class V>
 using umap = std::unordered_multimap<K, V>;
 using std::to_string;
@@ -87,10 +98,14 @@ inline const umap<std::string,
         "Esirkepov_density_decomposition",
     }},
     // Diagnostics with their config parameters
-    { "energy",          { "empty description" }},
-    { "density",         { "0", "0", to_string(SIZE_X * dx), to_string(SIZE_Y * dy), "0.05", "0.05" }},
-    { "first_Vx_moment", { "0", "0", to_string(SIZE_X * dx), to_string(SIZE_Y * dy), "0.05", "0.05" }},
-    { "first_Vy_moment", { "0", "0", to_string(SIZE_X * dx), to_string(SIZE_Y * dy), "0.05", "0.05" }},
+    { "energy", { "empty description" }},
+
+    { "density", { "0", "0", to_string(SIZE_X * dx), to_string(SIZE_Y * dy), "0.05", "0.05" }},
+
+    { "x0_distribution_function", { to_string(damping_layer_width), to_string(-4 * V_ions), to_string(-4 * V_ions), to_string(+4 * V_ions), to_string(+4 * V_ions), to_string(+8 * V_ions / 200), to_string(+8 * V_ions / 200) }},
+    { "x0_distribution_function", { "400", to_string(-4 * V_ions), to_string(-4 * V_ions), to_string(+4 * V_ions), to_string(+4 * V_ions), to_string(+8 * V_ions / 200), to_string(+8 * V_ions / 200) }},
+    { "x0_distribution_function", { "800", to_string(-4 * V_ions), to_string(-4 * V_ions), to_string(+4 * V_ions), to_string(+4 * V_ions), to_string(+8 * V_ions / 200), to_string(+8 * V_ions / 200) }},
+    { "x0_distribution_function", { "840", to_string(-4 * V_ions), to_string(-4 * V_ions), to_string(+4 * V_ions), to_string(+4 * V_ions), to_string(+8 * V_ions / 200), to_string(+8 * V_ions / 200) }},
   }},
 #endif
 
@@ -117,21 +132,18 @@ inline const umap<std::string,
 #endif
 };
 
-inline const int damping_layer_width = 30;
-inline const double damping_factor = 0.8;
-
-// Domain_geometry
-inline const double domain_left   = damping_layer_width * dx;
-inline const double domain_right  = (SIZE_X - damping_layer_width) * dx;
-inline const double domain_bottom = 0;
-inline const double domain_top    = SIZE_Y * dy;
-
 inline const umap<std::string, std::vector<std::string>> fields_diagnostics = {
 #if there_are_fields && fields_are_diagnosed
   { "energy",      { "empty description" }},
+
+  { "whole_field", { "J", "x", "0", "0", to_string(SIZE_X), to_string(SIZE_Y) }},
+  { "whole_field", { "J", "y", "0", "0", to_string(SIZE_X), to_string(SIZE_Y) }},
   { "whole_field", { "E", "x", "0", "0", to_string(SIZE_X), to_string(SIZE_Y) }},
   { "whole_field", { "E", "y", "0", "0", to_string(SIZE_X), to_string(SIZE_Y) }},
   { "whole_field", { "B", "z", "0", "0", to_string(SIZE_X), to_string(SIZE_Y) }},
+
+  { "field_on_segment", { "J", "y", "0", to_string(SIZE_Y / 2), to_string(SIZE_X), to_string(SIZE_Y / 2) }},
+  { "field_on_segment", { "E", "x", "0", to_string(SIZE_Y / 2), to_string(SIZE_X), to_string(SIZE_Y / 2) }},
 #endif
 };
 

--- a/src/diagnostics/chosen_particles.cpp
+++ b/src/diagnostics/chosen_particles.cpp
@@ -7,7 +7,7 @@ namespace fs = std::filesystem;
 std::vector<int> choose_indexes(const std::vector<Particle>& particles) {
   std::vector<int> indexes_of_chosen_particles;
 
-  for(decltype(particles.size()) i = 0; i < particles.size(); i += config::Npe) {
+  for(size_t i = 0u; i < particles.size(); i += config::Npi) {
     auto& point = particles[i].point;
 
     double x = round(point.x() / dx);
@@ -31,7 +31,7 @@ chosen_particles::chosen_particles(
       indexes_of_chosen_particles_(std::move(indexes_of_chosen_particles)) {
   save_parameters();
 
-  for(int i = 0; i < indexes_of_chosen_particles_.size(); ++i) {
+  for(size_t i = 0u; i < indexes_of_chosen_particles_.size(); ++i) {
     files_for_results_.emplace_back(std::make_unique<BIN_File>(
       result_directory_, std::to_string(i) + "_particle"));
   }

--- a/src/diagnostics/diagnostics_builder.cpp
+++ b/src/diagnostics/diagnostics_builder.cpp
@@ -7,6 +7,7 @@
 
 #include "src/diagnostics/chosen_particles.hpp"
 #include "src/diagnostics/distribution_moment.hpp"
+#include "src/diagnostics/x0_distribution_function.hpp"
 
 Diagnostics_builder::Diagnostics_builder(
     std::vector<Particles>& particles_species, Fields& fields)
@@ -87,6 +88,11 @@ vector_of_diagnostics Diagnostics_builder::build() {
       LOG_INFO("Add first_Vphi_moment diagnostic for {}", sort);
       diagnostics.emplace_back(build_diag_distribution_moment(
         sort, "first_Vphi_moment", "XY", diag_description));
+    }
+    else if (diag == "x0_distribution_function") {
+      LOG_INFO("Add x0_distribution_function diagnostic for {}", sort);
+      diagnostics.emplace_back(build_diag_x0_distribution_function(
+        sort, diag_description));
     }
   }}
 #endif
@@ -240,4 +246,22 @@ Diagnostics_builder::build_diag_distribution_moment(
     particles_species_.at(sort_name),
     std::make_unique<Moment>(moment_name),
     std::make_unique<Projector2D>(axes_names, area));
+}
+
+inline std::unique_ptr<Diagnostic>
+Diagnostics_builder::build_diag_x0_distribution_function(
+    const std::string& sort_name,
+    const std::vector<std::string>& description) {
+  int x0 = std::stoi(description[0]);
+
+  diag_area area{
+    std::stod(description[1]), std::stod(description[2]),
+    std::stod(description[3]), std::stod(description[4]),
+    std::stod(description[5]), std::stod(description[6]),
+  };
+
+  return std::make_unique<x0_distribution_function>(
+    dir_name + "/" + sort_name,
+    particles_species_.at(sort_name),
+    x0, area);
 }

--- a/src/diagnostics/diagnostics_builder.hpp
+++ b/src/diagnostics/diagnostics_builder.hpp
@@ -43,6 +43,11 @@ class Diagnostics_builder {
     const std::string& moment_name,
     const std::string& axes_names,
     const std::vector<std::string>& description);
+
+  inline std::unique_ptr<Diagnostic>
+  build_diag_x0_distribution_function(
+    const std::string& sort_name,
+    const std::vector<std::string>& description);
 };
 
 #endif  // SRC_DIAGNOSTICS_DIAGNOSTICS_BUILDER_HPP

--- a/src/diagnostics/distribution_moment.cpp
+++ b/src/diagnostics/distribution_moment.cpp
@@ -23,6 +23,24 @@ distribution_moment::distribution_moment(
   save_parameters();
 }
 
+distribution_moment::distribution_moment(
+  std::string result_directory,
+  const Particles& particles,
+  int x0, std::unique_ptr<Projector2D> projector)
+  : Diagnostic(result_directory + "/x0=" + std::to_string(x0) + "_distribution_function"),
+    particles_(particles) {
+  moment_ = nullptr;
+  projector_ = std::move(projector);
+
+  min_[X] = int(projector_->area.min[X] / projector_->area.dp[X]);
+  min_[Y] = int(projector_->area.min[Y] / projector_->area.dp[Y]);
+  max_[X] = int(projector_->area.max[X] / projector_->area.dp[X]);
+  max_[Y] = int(projector_->area.max[Y] / projector_->area.dp[Y]);
+  data_.reserve((max_[X] - min_[X]) * (max_[Y] - min_[Y]));
+
+  save_parameters();
+}
+
 void distribution_moment::save_parameters() const {
   fs::create_directories(fs::path(result_directory_));
 
@@ -71,8 +89,8 @@ void distribution_moment::collect() {
     int npx = int(round(pr_x / projector_->area.dp[X]));
     int npy = int(round(pr_y / projector_->area.dp[Y]));
 
-    if ((min_[X] < npx && npx < max_[X]) &&
-        (min_[Y] < npy && npy < max_[Y])) {
+    if ((min_[X] <= npx && npx < max_[X]) &&
+        (min_[Y] <= npy && npy < max_[Y])) {
       #pragma omp atomic
       data_[(npy - min_[Y]) * (max_[X] - min_[X]) +
         (npx - min_[X])] += moment_->get(particle) / Np;

--- a/src/diagnostics/distribution_moment.cpp
+++ b/src/diagnostics/distribution_moment.cpp
@@ -86,8 +86,9 @@ void distribution_moment::collect() {
     double pr_x = projector_->get_x(particle);
     double pr_y = projector_->get_y(particle);
 
-    int npx = int(round(pr_x / projector_->area.dp[X]));
-    int npy = int(round(pr_y / projector_->area.dp[Y]));
+    // floor(x) here to avoid problems on borders with rounding up and down
+    int npx = int(floor(pr_x / projector_->area.dp[X]));
+    int npy = int(floor(pr_y / projector_->area.dp[Y]));
 
     if ((min_[X] <= npx && npx < max_[X]) &&
         (min_[Y] <= npy && npy < max_[Y])) {

--- a/src/diagnostics/distribution_moment.hpp
+++ b/src/diagnostics/distribution_moment.hpp
@@ -20,8 +20,13 @@ class distribution_moment : public Diagnostic {
 
   void save_parameters() const override;
 
- private:
-  void collect();
+ protected:
+  distribution_moment(
+    std::string result_directory,
+    const Particles& particles,
+    int x0, std::unique_ptr<Projector2D>);
+
+  virtual void collect();
   void reset();
 
   const Particles& particles_;

--- a/src/diagnostics/field_on_segment.cpp
+++ b/src/diagnostics/field_on_segment.cpp
@@ -30,7 +30,7 @@ void field_on_segment::save_parameters() const {
 void field_on_segment::diagnose(int t) {
   PROFILE_FUNCTION();
   
-  if (t % diagnose_time_step != 0) return;
+  // if (t % diagnose_time_step != 0) return;
 
   file_for_results_ = std::make_unique<BIN_File>(
     result_directory_, std::to_string(t));
@@ -45,8 +45,8 @@ void field_on_segment::diagnose(int t) {
 
 constexpr bool field_on_segment::belongs_to_segment(int x, int y) const {
   return
-    (segment_.begin[X] < x && x < segment_.end[X]) &&
-    (segment_.begin[Y] < y && y < segment_.end[Y]) &&
+    (segment_.begin[X] <= x && x <= segment_.end[X]) &&
+    (segment_.begin[Y] <= y && y <= segment_.end[Y]) &&
     ((y - segment_.begin[Y]) * (segment_.end[X] - segment_.begin[X]) ==
      (x - segment_.begin[X]) * (segment_.end[Y] - segment_.begin[Y]));
 }

--- a/src/diagnostics/x0_distribution_function.cpp
+++ b/src/diagnostics/x0_distribution_function.cpp
@@ -1,0 +1,58 @@
+#include "x0_distribution_function.hpp"
+#include "src/file_writers/bin_file.hpp"
+
+namespace fs = std::filesystem;
+
+x0_distribution_function::x0_distribution_function(
+  std::string result_directory,
+  const Particles& particles,
+  int x0, diag_area area)
+  : distribution_moment(
+      result_directory, particles, x0,
+      std::make_unique<Projector2D>("VxVy", area)),
+    x0_(x0) {}
+
+void x0_distribution_function::save_parameters() const {
+  fs::create_directories(fs::path(result_directory_));
+
+  std::ofstream diagnostic_parameters_((result_directory_ +
+    "/parameters.txt").c_str(), std::ios::out);
+
+  diagnostic_parameters_ << "#TIME, dt, DTS\n" <<
+    TIME << " " << dt << " " << diagnose_time_step << " \n";
+
+  diagnostic_parameters_ << "#x0\n" << x0_ << " \n";
+
+  diagnostic_parameters_ << "#npx_min, npx_max, dpx\n" <<
+    min_[X] << " " << max_[X] << " " << projector_->area.dp[X] << " \n";
+
+  diagnostic_parameters_ << "#npy_min, npy_max, dpy\n" <<
+    min_[Y] << " " << max_[Y] << " " << projector_->area.dp[Y] << " \n";
+
+  diagnostic_parameters_ << "#sizeof(float)\n" <<
+    sizeof(float) << " " << std::endl;
+}
+
+void x0_distribution_function::collect() {
+  int Np = particles_.get_parameters().Np();
+
+  #pragma omp parallel for
+  for (const auto& particle : particles_.get_particles()) {
+    if (fabs(particle.point.x() / dx - x0_) > 0.25)
+      continue;
+
+    double pr_x = projector_->get_x(particle);
+    double pr_y = projector_->get_y(particle);
+
+    int npx = int(round(pr_x / projector_->area.dp[X]));
+    int npy = int(round(pr_y / projector_->area.dp[Y]));
+
+    if ((min_[X] < npx && npx < max_[X]) &&
+        (min_[Y] < npy && npy < max_[Y])) {
+      #pragma omp atomic
+      data_[(npy - min_[Y]) * (max_[X] - min_[X]) +
+        (npx - min_[X])] += particle.n() / Np;
+    }
+    else continue;
+  }
+}

--- a/src/diagnostics/x0_distribution_function.cpp
+++ b/src/diagnostics/x0_distribution_function.cpp
@@ -44,8 +44,9 @@ void x0_distribution_function::collect() {
     double pr_x = projector_->get_x(particle);
     double pr_y = projector_->get_y(particle);
 
-    int npx = int(round(pr_x / projector_->area.dp[X]));
-    int npy = int(round(pr_y / projector_->area.dp[Y]));
+    // floor(x) here to avoid problems on borders with rounding up and down
+    int npx = int(floor(pr_x / projector_->area.dp[X]));
+    int npy = int(floor(pr_y / projector_->area.dp[Y]));
 
     if ((min_[X] < npx && npx < max_[X]) &&
         (min_[Y] < npy && npy < max_[Y])) {

--- a/src/diagnostics/x0_distribution_function.hpp
+++ b/src/diagnostics/x0_distribution_function.hpp
@@ -1,0 +1,23 @@
+#ifndef SRC_DIAGNOSTICS_X0_DISTRIBUTION_FUNCTION_HPP
+#define SRC_DIAGNOSTICS_X0_DISTRIBUTION_FUNCTION_HPP
+
+#include "diagnostic.hpp"
+#include "src/diagnostics/distribution_moment.hpp"
+
+/// @todo think how to make this diagnostic more general
+class x0_distribution_function : public distribution_moment {
+ public:
+  x0_distribution_function(
+    std::string result_directory,
+    const Particles& particles,
+    int x0, diag_area area);
+
+  void save_parameters() const override;
+
+ private:
+  void collect() override;
+
+  int x0_;
+};
+
+#endif  // SRC_DIAGNOSTICS_X0_DISTRIBUTION_FUNCTION_HPP

--- a/src/fields/open_boundaries_processor.cpp
+++ b/src/fields/open_boundaries_processor.cpp
@@ -21,6 +21,7 @@ void Open_boundaries_processor::process() {
   // top_bottom_bounds();
 }
 
+// #define COPYING_FIELDS_TO_THE_BUFFER_CELLS
 void Open_boundaries_processor::left_right_bounds() {
   // * . . * >x
   // *     *
@@ -29,6 +30,19 @@ void Open_boundaries_processor::left_right_bounds() {
 
   #pragma omp parallel for num_threads(NUM_THREADS)
   for (int y = 0; y < fields_E.size_y(); ++y) {
+#ifdef COPYING_FIELDS_TO_THE_BUFFER_CELLS
+    for (int copy_to_x = layer.width; copy_to_x > layer.width - 3; --copy_to_x) {
+      int copy_from_x = layer.width + 1;
+      fields_E.x(y, copy_to_x) = fields_E.x(y, copy_from_x);
+      fields_E.y(y, copy_to_x) = fields_E.y(y, copy_from_x);
+      fields_E.z(y, copy_to_x) = fields_E.z(y, copy_from_x);
+
+      fields_B.x(y, copy_to_x) = fields_B.x(y, copy_from_x);
+      fields_B.y(y, copy_to_x) = fields_B.y(y, copy_from_x);
+      fields_B.z(y, copy_to_x) = fields_B.z(y, copy_from_x);
+    }
+#endif
+
     for (int x = 0; x < layer.width; ++x) {
       // left
       double coeff = layer.damping_coeff(x);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "src/managers/manager.hpp"
 
 int main(int argc, char const *argv[]) {
+  /// @todo Date and time of the log, to separate them automatically
   LOG_INIT("log/simulation.log");
   BEGIN_SESSION("log/simulation_time_profile.json");
 

--- a/src/managers/manager.cpp
+++ b/src/managers/manager.cpp
@@ -4,9 +4,11 @@
 #include "src/command/magnetic_field_half_step.hpp"
 #include "src/command/set_particles.hpp"
 #include "src/command/clone_layer_particles.hpp"
+#include "src/command/copy_coordinates.hpp"
 
 #include "src/fields/fields_builder.hpp"
 #include "src/particles/particles_builder.hpp"
+#include "src/particles/particles_load.hpp"
 #include "src/diagnostics/diagnostics_builder.hpp"
 
 #include "src/utils/transition_layer/particles_distribution.hpp"
@@ -21,6 +23,8 @@ void Manager::initializes() {
   Fields_builder fields_builder;
   fields_ = Fields(fields_builder);
 
+  // We use this to push the magnetic field to
+  // the same half-timestep as electric field
   step_presets_.push_front(std::make_unique<Magnetic_field_half_step>(&fields_));
 
 #if there_are_Bz0
@@ -38,7 +42,7 @@ void Manager::initializes() {
   particles_builder.set_sort("plasma_ions");
   Particles& plasma_ions = particles_species_.emplace_back(particles_builder);
 
-  plasma_ions.boundaries_processor_ = std::make_unique<Plasma_boundary_processor>(
+  plasma_ions.boundaries_processor_ = std::make_unique<Beam_boundary_processor>(
     plasma_ions.particles_, plasma_ions.parameters_,
     Domain_geometry(
       config::domain_left,
@@ -49,33 +53,43 @@ void Manager::initializes() {
   );
 
   auto generator = std::make_unique<transition_layer::Random_coordinate_generator>();
-  int num_particles_to_load = generator->get_particles_number();
+  int num_ions = generator->get_particles_number();
 
-  LOG_INFO("{} plasma ions will be set", num_particles_to_load);
+  LOG_INFO("{} {} will be set in total", num_ions, plasma_ions.get_name());
 
   presets.push_back(std::make_unique<Set_particles>(
-    &plasma_ions, num_particles_to_load,
+    &plasma_ions, num_ions,
     std::move(generator),
-    transition_layer::load_ions_impulse
+    transition_layer::load_monoenergetic_impulse
   ));
 
   Particles& buffer_ions = particles_species_.emplace_back(particles_builder);
   buffer_ions.sort_name_ = "buffer_plasma_ions";  // changed from "plasma_ions"
 
-  buffer_ions.boundaries_processor_ = std::make_unique<Buffer_processor>(
-    buffer_ions.particles_, buffer_ions.parameters_
-  );
+  generator = std::make_unique<transition_layer::Boundary_coordinate_generator>();
+  int num_buffer_ions = generator->get_particles_number();
 
-  step_presets_.push_back(std::make_unique<Clone_layer_particles>(
-    &plasma_ions,
-    &buffer_ions,
+  LOG_INFO("{} {} will be set (each timestep) in {}-th cell",
+    num_buffer_ions, buffer_ions.get_name(), config::damping_layer_width - 1);
+
+  /// @note step_presets_ used here to set particles each timestep
+  step_presets_.push_back(std::make_unique<Set_particles>(
+    &buffer_ions, num_buffer_ions,
+    std::move(generator),
+    transition_layer::load_monoenergetic_impulse
+  ));
+
+  buffer_ions.boundaries_processor_ = std::make_unique<Beam_buffer_processor>(
+    buffer_ions.particles_,
+    plasma_ions.particles_,
+    plasma_ions.parameters_,
     Domain_geometry(
       config::domain_left,
       config::domain_right,
       config::domain_bottom,
       config::domain_top
     )
-  ));
+  );
 #endif
 
   Diagnostics_builder diagnostics_builder(particles_species_, fields_);

--- a/src/managers/manager.cpp
+++ b/src/managers/manager.cpp
@@ -29,6 +29,8 @@ void Manager::initializes() {
 #endif
 
 #if there_are_particles && there_are_plasma_ions
+  assert(config::V_ions < 1 && "ions velocity is greater the c!");
+
   Particles_builder particles_builder(fields_);
 
   particles_builder.set_sort("plasma_ions");

--- a/src/particles/particle-boundary_processor.cpp
+++ b/src/particles/particle-boundary_processor.cpp
@@ -16,9 +16,13 @@ Particle_boundary_processor::Particle_boundary_processor(
 // according to the initial distribution
 vector3 Particle_boundary_processor::generate_moment(
     const Point& reference_point) {
-  double new_py = params_.p0() * sin(2 * M_PI * random_01());
+  double p0 = params_.p0();
+
+  double old_px = reference_point.px();
+  double new_py = random_sign() * p0 * sqrt(1.0 - pow(old_px / p0, 2.0));
   double new_pz = 0.0;
-  return { reference_point.px(), new_py, new_pz };
+
+  return { old_px, new_py, new_pz };
 }
 
 

--- a/src/particles/particle-boundary_processor.cpp
+++ b/src/particles/particle-boundary_processor.cpp
@@ -5,31 +5,43 @@
 #include "src/utils/random_number_generator.hpp"
 
 Particle_boundary_processor::Particle_boundary_processor(
-    std::vector<Particle>& particles_vec, Parameters& params,
-    Domain_geometry geom)
-    : particles_vec_(particles_vec), params_(params),
-      geom_(geom) {}
+    std::vector<Particle>& particles_vec,
+    Parameters& params, Domain_geometry geom)
+    : particles_vec_(particles_vec), params_(params), geom_(geom) {}
 
 // This generate_moment method is problem-specific.
 // As soon as our particles regenerated only near
 // the left boundary, we give them a moment
 // according to the initial distribution
-vector3 Particle_boundary_processor::generate_moment(
-    const Point& reference_point) {
+vector3 Particle_boundary_processor::
+generate_moment(const Point& reference_point) {
+  /// @warning
+  /// Implementation here isn't good. Because of the numerical
+  /// heating, particle px can be even bigger than p0 and here
+  /// we will calculate the root of the negative value
+  ///
+  /// @note
+  /// Maybe we can reduce new_py to the simpler version
+  ///   random_sign() * reference_point.py();
   double p0 = params_.p0();
 
-  double old_px = reference_point.px();
-  double new_py = random_sign() * p0 * sqrt(1.0 - pow(old_px / p0, 2.0));
+  double new_px = reference_point.px();
+  double new_py = random_sign() * p0 * sqrt(1.0 - (new_px / p0) * (new_px / p0));
   double new_pz = 0.0;
 
-  return { old_px, new_py, new_pz };
+  return { new_px, new_py, new_pz };
 }
 
 
+Plasma_boundary_processor::Plasma_boundary_processor(
+    std::vector<Particle>& particles_vec,
+    Parameters& params, Domain_geometry geom)
+    : Particle_boundary_processor(particles_vec, params, geom) {}
+
 // If a particle moves from the zero cell to the first one,
 // a new particle with the shifted x-coordinate is created
-void Plasma_boundary_processor::add(
-    Point& reference_point, const vector2& r0) {
+void Plasma_boundary_processor::
+add(Point& reference_point, const vector2& r0) {
 
   periodic_y(reference_point, geom_.bottom, geom_.top);
 
@@ -38,19 +50,13 @@ void Plasma_boundary_processor::add(
   if (passed_through_left(r0.x(), reference_point.x())) {
     particle_to_be_added = true;
     new_r = { reference_point.x() - dx, reference_point.y() };
-    LOG_TRACE("Particle passed through the left={:.5f}: x0={:.5f}, x={:.5f}",
-      geom_.left, r0.x(), reference_point.x());
   }
   else if (passed_through_right(r0.x(), reference_point.x())) {
     particle_to_be_added = true;
     new_r = { reference_point.x() + dx, reference_point.y() };
-    LOG_TRACE("Particle passed through the right={:.5f}: x0={:.5f}, x={:.5f}",
-      geom_.right, r0.x(), reference_point.x());
   }
 
   if (!particle_to_be_added) return;
-  LOG_TRACE("Creating a new one with x={:.5f}", new_r.x());
-
   vector3&& new_p = generate_moment(reference_point);
 
   /// @todo make emplace parallel with emplacing them by hand,
@@ -93,4 +99,55 @@ void Plasma_boundary_processor::remove() {
     LOG_TRACE("{} particle(s) removed", particles_vec_.end() - new_last);
     particles_vec_.erase(new_last, particles_vec_.end());
   }
+}
+
+
+Beam_boundary_processor::Beam_boundary_processor(
+    std::vector<Particle>& particles_vec,
+    Parameters& params, Domain_geometry geom)
+    : Plasma_boundary_processor(particles_vec, params, geom) {}
+
+void Beam_boundary_processor::
+add(Point& reference_point, const vector2& r0) {
+  periodic_y(reference_point, geom_.bottom, geom_.top);
+}
+
+
+Beam_buffer_processor::Beam_buffer_processor(
+    std::vector<Particle>& buff_beam_vec,
+    std::vector<Particle>& main_beam_vec,
+    Parameters& main_params,
+    Domain_geometry geom)
+    : Plasma_boundary_processor(buff_beam_vec, main_params, geom),
+      main_beam_vec_(main_beam_vec) {}
+
+void Beam_buffer_processor::
+add(Point& reference_point, const vector2& r0) {
+  periodic_y(reference_point, geom_.bottom, geom_.top);
+}
+
+void Beam_buffer_processor::remove() {
+  PROFILE_FUNCTION();
+
+  // Firstly, we remove particle that wasn't pass the border 
+  Plasma_boundary_processor::remove();
+
+  // Secondly, we move remaining particles to the main vector
+  LOG_TRACE("{} particles will come from buffer", particles_vec_.size());
+
+  for (const auto& particle : particles_vec_) {
+    main_beam_vec_.emplace_back(
+      particles_vec_.size(),
+      Point {
+        { particle.point.x(),  particle.point.y() },
+        { particle.point.px(), particle.point.py(), particle.point.pz() }
+      },
+      params_);
+  }
+
+  LOG_TRACE("{} particles in the {} after merging buffer",
+    main_beam_vec_.size(), params_.sort_name_);
+
+  // Thirdly, clear the buffer
+  particles_vec_.clear();
 }

--- a/src/particles/particle-boundary_processor.hpp
+++ b/src/particles/particle-boundary_processor.hpp
@@ -26,9 +26,8 @@ struct Domain_geometry {
 
 class Particle_boundary_processor {
  public:
-  Particle_boundary_processor(
-    std::vector<Particle>& particles_vec, Parameters& params,
-    Domain_geometry geom);
+  Particle_boundary_processor(std::vector<Particle>& particles_vec,
+    Parameters& params, Domain_geometry geom);
 
   virtual void add(Point& reference_point, const vector2& r0) = 0;
   virtual void remove() = 0;
@@ -45,8 +44,7 @@ class Particle_boundary_processor {
 class Plasma_boundary_processor : public Particle_boundary_processor {
  public:
   Plasma_boundary_processor(std::vector<Particle>& particles_vec,
-    Parameters& params, Domain_geometry geom)
-    : Particle_boundary_processor(particles_vec, params, geom) {}
+    Parameters& params, Domain_geometry geom);
 
   void add(Point& reference_point, const vector2& r0) override;
   void remove() override;
@@ -60,21 +58,35 @@ class Plasma_boundary_processor : public Particle_boundary_processor {
 class Beam_boundary_processor : public Plasma_boundary_processor {
  public:
   Beam_boundary_processor(std::vector<Particle>& particles_vec,
-    Parameters& params, Domain_geometry geom)
-    : Plasma_boundary_processor(particles_vec, params, geom) {}
+    Parameters& params, Domain_geometry geom);
 
-  void add(Point& reference_point, const vector2& r0) override {}
+  void add(Point& reference_point, const vector2& r0) override;
 };
 
 
-class Buffer_processor : public Particle_boundary_processor {
+class Plasma_buffer_processor : public Particle_boundary_processor {
  public:
-  Buffer_processor(std::vector<Particle>& particles_vec,
-    Parameters& params)
+  Plasma_buffer_processor(std::vector<Particle>& particles_vec, Parameters& params)
     : Particle_boundary_processor(particles_vec, params, Domain_geometry()) {}
 
   void add(Point& reference_point, const vector2& r0) override {}
   void remove() override { particles_vec_.clear(); }
+};
+
+
+class Beam_buffer_processor : public Plasma_boundary_processor {
+ public:
+  Beam_buffer_processor(
+    std::vector<Particle>& buff_beam_vec,
+    std::vector<Particle>& main_beam_vec,
+    Parameters& main_params,
+    Domain_geometry geom);
+
+  void add(Point& reference_point, const vector2& r0) override;
+  void remove() override;
+
+ private:
+  std::vector<Particle>& main_beam_vec_;
 };
 
 #endif  // SRC_PARTICLES_PARTICLE_BOUNDARY_PROCESSOR_HPP

--- a/src/particles/particle-boundary_processor.hpp
+++ b/src/particles/particle-boundary_processor.hpp
@@ -17,6 +17,8 @@ struct Domain_geometry {
   double bottom;
   double top;
 
+  Domain_geometry() = default;
+
   Domain_geometry(double left, double right, double bottom, double top)
     : left(left), right(right), bottom(bottom), top(top) {}
 };
@@ -62,6 +64,17 @@ class Beam_boundary_processor : public Plasma_boundary_processor {
     : Plasma_boundary_processor(particles_vec, params, geom) {}
 
   void add(Point& reference_point, const vector2& r0) override {}
+};
+
+
+class Buffer_processor : public Particle_boundary_processor {
+ public:
+  Buffer_processor(std::vector<Particle>& particles_vec,
+    Parameters& params)
+    : Particle_boundary_processor(particles_vec, params, Domain_geometry()) {}
+
+  void add(Point& reference_point, const vector2& r0) override {}
+  void remove() override { particles_vec_.clear(); }
 };
 
 #endif  // SRC_PARTICLES_PARTICLE_BOUNDARY_PROCESSOR_HPP

--- a/src/particles/particle/parameters.hpp
+++ b/src/particles/particle/parameters.hpp
@@ -114,6 +114,8 @@ public:
 	const std::string& n_type() { return n_->get_type(); }
 	const std::string& q_type() { return q_->get_type(); }
 
+	std::string sort_name_;
+
 private:
 	int Np_;
 	double m_;

--- a/src/particles/particle/point_bound_interact.cpp
+++ b/src/particles/particle/point_bound_interact.cpp
@@ -26,7 +26,7 @@ void periodic_x(Point& point, double left, double right) {
   if (point.x() < left) {
     point.x() = right - (left - point.x());
   }
-  else if (point.x() > right) {
+  else if (point.x() >= right) {
     point.x() = left + (point.x() - right);
   }
 }
@@ -35,7 +35,7 @@ void periodic_y(Point& point, double bottom, double top) {
   if (point.y() < bottom) {
     point.y() = top - (bottom - point.y());
   }
-  else if (point.y() > top) {
+  else if (point.y() >= top) {
     point.y() = bottom + (point.y() - top);
   }
 }

--- a/src/particles/particles.cpp
+++ b/src/particles/particles.cpp
@@ -8,6 +8,7 @@
 Particles::Particles(Particles_builder& builder) {
   sort_name_ = builder.get_sort_name();
   parameters_ = builder.build_parameters();
+  parameters_.sort_name_ = sort_name_;
 
   push_ = builder.build_pusher();
   interpolation_ = builder.build_interpolation(this->parameters_);

--- a/src/particles/particles.cpp
+++ b/src/particles/particles.cpp
@@ -12,16 +12,6 @@ Particles::Particles(Particles_builder& builder) {
   push_ = builder.build_pusher();
   interpolation_ = builder.build_interpolation(this->parameters_);
   decomposition_ = builder.build_decomposition(this->parameters_);
-
-  boundaries_processor_ = std::make_unique<Plasma_boundary_processor>(
-    this->particles_, this->parameters_,
-    Domain_geometry(
-      config::domain_left,
-      config::domain_right,
-      config::domain_bottom,
-      config::domain_top
-    )
-  );
 }
 
 /// @warning Algorithm ends up with seg. fault

--- a/src/particles/particles.hpp
+++ b/src/particles/particles.hpp
@@ -23,7 +23,9 @@ class Particles {
 
   void push();
 
-  /// @todo refactor this out
+  /// @todo REFACTOR THIS OUT!
+  friend class Manager;
+
   friend class Set_particles;
   friend class Copy_coordinates;
   friend class Ionize_particles;

--- a/src/particles/particles_load.cpp
+++ b/src/particles/particles_load.cpp
@@ -4,46 +4,41 @@
 #include "src/utils/random_number_generator.hpp"
 
 void fill_randomly(int sequential_number, int Np,
-		int cell_number_nx, int cell_number_ny,
-		double* x, double* y) {
-	static auto distribution = std::uniform_real_distribution(0.0, 1.0);
-	
-	*x = (cell_number_nx + distribution(Random_generator::get())) * dx;  
-	*y = (cell_number_ny + distribution(Random_generator::get())) * dy;  
+    int cell_number_nx, int cell_number_ny,
+    double* x, double* y) {
+  *x = (cell_number_nx + random_01()) * dx;
+  *y = (cell_number_ny + random_01()) * dy;
 }
 
 void fill_periodically(int sequential_number, int Np,
-	int cell_number_nx, int cell_number_ny,
-	double* x, double* y) {
-	/** 
-	 * i%Np -- номер от нуля до Np-1 частицы в одной ячейке
-	 * i/Np -- список индексов, эквивалентный перебору ячеек
-	 * индекс ячейки по Ox: (i/Np % divider), Oy: (i/Np / divider).
-	 *
-	 * Cколько по длинне в ячейку влазит? Это надо искать делители Np
-	 * при том лучше, конечно, от половины Np начинать в обе стороны искать
-	 * Пока эта проблема решена так: divider -- число, показывающее 
-	 * сколько частиц будет уложено в одну ячейку вдоль оси Ox; 
-	 */
-	
-	int divider = 2;
-	*x = cell_number_nx * dx + ((sequential_number % Np) % divider) * dx / divider;
-	*y = cell_number_ny * dy + ((sequential_number % Np) / divider) * dy / (Np / divider); 
+  int cell_number_nx, int cell_number_ny,
+  double* x, double* y) {
+  /**
+   * i%Np -- номер от нуля до Np-1 частицы в одной ячейке
+   * i/Np -- список индексов, эквивалентный перебору ячеек
+   * индекс ячейки по Ox: (i/Np % divider), Oy: (i/Np / divider).
+   *
+   * Cколько по длинне в ячейку влазит? Это надо искать делители Np
+   * при том лучше, конечно, от половины Np начинать в обе стороны искать
+   * Пока эта проблема решена так: divider -- число, показывающее
+   * сколько частиц будет уложено в одну ячейку вдоль оси Ox;
+   */
+
+  int divider = 2;
+  *x = cell_number_nx * dx + ((sequential_number % Np) % divider) * dx / divider;
+  *y = cell_number_ny * dy + ((sequential_number % Np) / divider) * dy / (Np / divider);
 }
 
 
 double temperature_impulse(double temperature, double mass) {
-	static auto distribution = std::uniform_real_distribution(0.0, 1.0);
-
-	static const double mec2 = 511.0;
-	return sin(2.0 * M_PI * distribution(Random_generator::get())) *
-		sqrt(-2.0 * (temperature * mass / mec2)*log(distribution(Random_generator::get()))); 
+  static const double mec2 = 511.0;
+  return sqrt(-2.0 * (temperature * mass / mec2) * log(random_01()));
 }
 
 void load_uniform_impulse(double x, double y,
-		double mass, double Tx, double Ty, double Tz,
-		double p0, double* px, double* py, double* pz) {
-	*px = temperature_impulse(Tx, mass);
-	*py = temperature_impulse(Ty, mass); 
-	*pz = temperature_impulse(Tz, mass); 	
+    double mass, double Tx, double Ty, double Tz,
+    double p0, double* px, double* py, double* pz) {
+  *px = sin(2.0 * M_PI * random_01()) * temperature_impulse(Tx, mass);
+  *py = sin(2.0 * M_PI * random_01()) * temperature_impulse(Ty, mass);
+  *pz = sin(2.0 * M_PI * random_01()) * temperature_impulse(Tz, mass);
 }

--- a/src/particles/particles_load.hpp
+++ b/src/particles/particles_load.hpp
@@ -7,4 +7,9 @@ void load_uniform_impulse(double x, double y,
   double mass, double Tx, double Ty, double Tz,
   double p0, double* px, double* py, double* pz);
 
+using impulse_loader = std::function<
+void(double x, double y,
+  double mass, double Tx, double Ty, double Tz,
+  double p0, double* px, double* py, double* pz)>;
+
 #endif  // SRC_PARTICLES_PARTICLES_LOAD_HPP

--- a/src/particles/particles_load.hpp
+++ b/src/particles/particles_load.hpp
@@ -1,6 +1,8 @@
 #ifndef SRC_PARTICLES_PARTICLES_LOAD_HPP
 #define SRC_PARTICLES_PARTICLES_LOAD_HPP
 
+#include "src/pch.h"
+
 double temperature_impulse(double temperature, double mass);
 
 void load_uniform_impulse(double x, double y,

--- a/src/particles/particles_load.hpp
+++ b/src/particles/particles_load.hpp
@@ -1,8 +1,6 @@
 #ifndef SRC_PARTICLES_PARTICLES_LOAD_HPP
 #define SRC_PARTICLES_PARTICLES_LOAD_HPP
 
-/// @todo impulse loader?
-
 double temperature_impulse(double temperature, double mass);
 
 void load_uniform_impulse(double x, double y,

--- a/src/utils/random_number_generator.hpp
+++ b/src/utils/random_number_generator.hpp
@@ -1,3 +1,5 @@
+#include <omp.h>
+
 #include <random>
 
 /**
@@ -17,7 +19,8 @@ class Random_generator {
   }
 
  private:
-  std::minstd_rand gen;
+  std::random_device rd;
+  std::minstd_rand gen = std::minstd_rand(rd());
 
   Random_generator() = default;
 
@@ -29,7 +32,7 @@ class Random_generator {
 };
 
 inline double random_01() {
-  static auto distribution = std::uniform_real_distribution(0.0, 1.0);
+  static std::uniform_real_distribution distribution(0.0, 1.0);
 
   double value;
 
@@ -37,6 +40,17 @@ inline double random_01() {
   /// down, try here: #pragma omp atomic
   #pragma omp critical
   value = distribution(Random_generator::get());
+
+  return value;
+}
+
+inline int random_sign() { 
+  static std::bernoulli_distribution distribution(0.5);
+
+  int value;
+
+  #pragma omp critical
+  value = distribution(Random_generator::get()) ? +1 : -1;
 
   return value;
 }

--- a/src/utils/random_number_generator.hpp
+++ b/src/utils/random_number_generator.hpp
@@ -30,5 +30,13 @@ class Random_generator {
 
 inline double random_01() {
   static auto distribution = std::uniform_real_distribution(0.0, 1.0);
-  return distribution(Random_generator::get());
+
+  double value;
+
+  /// @todo critical section can slow everything
+  /// down, try here: #pragma omp atomic
+  #pragma omp critical
+  value = distribution(Random_generator::get());
+
+  return value;
 }

--- a/src/utils/transition_layer/evaluate_function.py
+++ b/src/utils/transition_layer/evaluate_function.py
@@ -10,7 +10,7 @@ import numpy as np
 
 x0 = 20.0   # , c/wp - Start coordinate 
 dx = 0.05   # , c/wp - Grid spacing
-mi = 400.0  # , me - Mass of ions
+mi = 16.0   # , me - Mass of ions
 me = 1.0    # , me - Mass of electrons
 
 eps = 1e-6  # Calculation tolerance
@@ -92,6 +92,8 @@ if rank == 0:
     x_range = np.arange(x0, x_value(-1.0)[0], dx)
 
     f_values = {x: float(interpolated_function(x)) for x in x_range}
+
+    np.save(evaluate_to, f_values)
 
     # Writing table function to the binary file, not mpi-parallel.
     parameters = [x0, x_range[-1], dx, mi, me]

--- a/src/utils/transition_layer/particles_distribution.cpp
+++ b/src/utils/transition_layer/particles_distribution.cpp
@@ -21,14 +21,14 @@ void Random_coordinate_generator::load(double* x, double* y) {
     
     *y = random_01() * SIZE_Y * dx;
   }
-  while (random_01() > get_probability(*x, *y));
+  while (random_01() > get_probability(*x));
 }
 
-double Random_coordinate_generator::get_probability(double x, double y) const {
+double Random_coordinate_generator::get_probability(double x) const {
   if (x <= __func.get_x0()) {
     return 1.0;
   }
-  else if (x < __func.get_xmax()) {
+  else if (x <= __func.get_xmax()) {
     return d_theta(x) / (2 * M_PI);
   }
   else {
@@ -39,8 +39,8 @@ double Random_coordinate_generator::get_probability(double x, double y) const {
 int Random_coordinate_generator::get_particles_number() const {
   double integral = 0;
 
-  for (double x = config::domain_left; x < __func.get_xmax(); x += dx) {
-    integral += get_probability(x, 0);
+  for (double x = config::domain_left; x <= __func.get_xmax(); x += dx) {
+    integral += get_probability(x);
   }
 
   return int(round(integral * SIZE_Y * config::Npi));
@@ -54,7 +54,7 @@ void load_ions_impulse(double x, double y,
   if (x <= __func.get_x0()) {
     theta = 2 * M_PI * random_01(); 
   }
-  else if (x < __func.get_xmax()) {
+  else if (x <= __func.get_xmax()) {
     theta = - M_PI - asin(__func.get_value(x)) + random_01() * d_theta(x);
   }
 

--- a/src/utils/transition_layer/particles_distribution.cpp
+++ b/src/utils/transition_layer/particles_distribution.cpp
@@ -18,10 +18,10 @@ void Random_coordinate_generator::load(double* x, double* y) {
   do {
     *x = config::domain_left + random_01() *
       (__func.get_xmax() - config::domain_left);
-    
-    *y = random_01() * SIZE_Y * dx;
   }
   while (random_01() > get_probability(*x));
+
+  *y = random_01() * SIZE_Y * dx;
 }
 
 double Random_coordinate_generator::get_probability(double x) const {

--- a/src/utils/transition_layer/particles_distribution.cpp
+++ b/src/utils/transition_layer/particles_distribution.cpp
@@ -21,7 +21,7 @@ void Random_coordinate_generator::load(double* x, double* y) {
   }
   while (random_01() > get_probability(*x));
 
-  *y = random_01() * SIZE_Y * dx;
+  *y = random_01() * SIZE_Y * dy;
 }
 
 double Random_coordinate_generator::get_probability(double x) const {
@@ -47,7 +47,17 @@ int Random_coordinate_generator::get_particles_number() const {
 }
 
 
-void load_ions_impulse(double x, double y,
+void Boundary_coordinate_generator::load(double* x, double* y) {
+  *x = config::domain_left + (random_01() - 1) * dx;
+  *y = random_01() * SIZE_Y * dy;
+}
+
+int Boundary_coordinate_generator::get_particles_number() const {
+  return SIZE_Y * config::Npi;
+}
+
+
+void load_monoenergetic_impulse(double x, double y,
     double mass, double Tx, double Ty, double Tz,
     double p0, double* px, double* py, double* pz) {
   double theta = 0.0;

--- a/src/utils/transition_layer/particles_distribution.cpp
+++ b/src/utils/transition_layer/particles_distribution.cpp
@@ -48,8 +48,8 @@ int Random_coordinate_generator::get_particles_number() const {
 
 
 void load_ions_impulse(double x, double y,
-	  double mass, double Tx, double Ty, double Tz,
-	  double p0, double* px, double* py, double* pz) {
+    double mass, double Tx, double Ty, double Tz,
+    double p0, double* px, double* py, double* pz) {
   double theta = 0.0;
   if (x <= __func.get_x0()) {
     theta = 2 * M_PI * random_01(); 

--- a/src/utils/transition_layer/particles_distribution.hpp
+++ b/src/utils/transition_layer/particles_distribution.hpp
@@ -9,7 +9,7 @@ class Random_coordinate_generator : public Coordinate_generator {
  public:
   Random_coordinate_generator() = default;
 
-  int get_particles_number() const;
+  virtual int get_particles_number() const;
 
   void load(double* x, double* y) override;
 
@@ -17,7 +17,16 @@ class Random_coordinate_generator : public Coordinate_generator {
   double get_probability(double x) const;
 };
 
-void load_ions_impulse(double x, double y,
+class Boundary_coordinate_generator : public Random_coordinate_generator {
+ public:
+  Boundary_coordinate_generator() = default;
+
+  int get_particles_number() const override;
+
+  void load(double* x, double* y) override;
+};
+
+void load_monoenergetic_impulse(double x, double y,
   double mass, double Tx, double Ty, double Tz,
   double p0, double* px, double* py, double* pz);
 

--- a/src/utils/transition_layer/particles_distribution.hpp
+++ b/src/utils/transition_layer/particles_distribution.hpp
@@ -14,7 +14,7 @@ class Random_coordinate_generator : public Coordinate_generator {
   void load(double* x, double* y) override;
 
  private:
-  double get_probability(double x, double y) const;
+  double get_probability(double x) const;
 };
 
 void load_ions_impulse(double x, double y,


### PR DESCRIPTION
Error occurred on the left boundary: with simple generation of

>`new_py = params_.p0() * sin(2 * M_PI * random_01())`,

according to the article 1, mentioned in https://github.com/vakurshakov/plasma_confinement/pull/6#issue-1419675932. The initial
monoenergetic distribution is destroyed after just 6 time steps.

So, the first solution was to change this generation onto generating
monoenergetic `py` according to the initial `p0`. However, numerical
heating causes the widening of the distribution near the initial one,
leading to the roots of negative values.

In current solution particles with initial monoenergetic distribution
are generated in the `-1` cell, then they can pass as `beam` particles
to the simulation domain. On the longer simulations this approach
lead to the non-heated distributions (see the last picture).

![06](https://user-images.githubusercontent.com/63333435/202886014-953e6580-17fb-42d5-90f3-a8fba32e1c91.png)

![0028](https://user-images.githubusercontent.com/63333435/202886045-a48b133a-4a22-4d5f-88b0-f659373d860a.png)

![00200](https://user-images.githubusercontent.com/63333435/202886463-f6694fe2-345a-4d02-8eea-a896d73dcda9.png)